### PR TITLE
feat: add swagger checks in new GitHub Actions workflow file

### DIFF
--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -59,13 +59,7 @@ jobs:
         run: |
           go install github.com/go-swagger/go-swagger/cmd/swagger@"${SWAGGER_VERSION:-latest}"
 
-          JSON_FILE=$(swagger validate docs/swagger.json)
-          YAML_FILE=$(swagger validate docs/swagger.yaml)
-          
-          if [[ "$JSON_FILE" =~ "is valid" ]] && [[ "$YAML_FILE" =~ "is valid" ]]; then
-            echo "error::The swagger specification files are not valid!"
-            exit 1
-          fi
+          swagger validate docs/swagger.json && swagger validate docs/swagger.yaml
 
-          echo "success::The Swagger specification files are valid!"
+          echo "The Swagger specification files are valid!"
           exit 0

--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -1,7 +1,8 @@
 name: Swagger checks
 
 on:
-  push
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   check-updates:
@@ -36,4 +37,3 @@ jobs:
           fi
 
           exit 0
-      

--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -62,9 +62,10 @@ jobs:
           JSON_FILE=$(swagger validate docs/swagger.json)
           YAML_FILE=$(swagger validate docs/swagger.yaml)
           
-          if [ ! "$JSON" =~ "is valid" -o ! "$JSON" =~ "is valid" ]; then
+          if [[ "$JSON_FILE" =~ "is valid" ]] && [[ "$YAML_FILE" =~ "is valid" ]]; then
             echo "error::The swagger specification files are not valid!"
             exit 1
           fi
 
+          echo "success::The Swagger specification files are valid!"
           exit 0

--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -37,3 +37,34 @@ jobs:
           fi
 
           exit 0
+
+  swagger-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Get Golang version
+        run: |
+          echo "Listing current dir" && ls
+          VERSION=$(cat go.mod | grep "go 1." | cut -d' ' -f2 | tr -d ' ''')
+          echo "GOLANG_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
+      - name: Validate files
+        run: |
+          go install github.com/go-swagger/go-swagger/cmd/swagger@"${SWAGGER_VERSION:-latest}"
+
+          JSON_FILE=$(swagger validate docs/swagger.json)
+          YAML_FILE=$(swagger validate docs/swagger.yaml)
+          
+          if [ ! "$JSON" =~ "is valid" -o ! "$JSON" =~ "is valid" ]; then
+            echo "error::The swagger specification files are not valid!"
+            exit 1
+          fi
+
+          exit 0

--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -1,0 +1,39 @@
+name: Swagger checks
+
+on:
+  push
+
+jobs:
+  check-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get Golang version
+        run: |
+          echo "Listing current dir" && ls
+          VERSION=$(cat go.mod | grep "go 1." | cut -d' ' -f2 | tr -d ' ''')
+          echo "GOLANG_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
+      - name: Check Swagger docs
+        run: |
+          go install github.com/swaggo/swag/cmd/swag@latest
+          swag init -d cmd/zipcodes/,http/rest,models/
+
+          SUMMARY=$(git diff --numstat ${DOCS_DIR_PATH:-./docs})
+          DIFFERENCES=$(git diff --color ${DOCS_DIR_PATH:-./docs})
+
+          if [ ! -z  "$SUMMARY" ]; then
+              echo "error::There are some swagger updates not committed yet"
+              echo "$DIFFERENCES"
+              exit 1
+          fi
+
+          exit 0
+      


### PR DESCRIPTION
## 🛠 Description of the updates/improvements to apply
We want to have some automated checks related to the `Swagger` documentation to prevent merge any PR with no commited `Swagger` docs updates

List of sequential subtasks(optional)

 1. Create the Swagger workflow file in the `.github/workflows directory`
 2. Add a Swagger job to check if there are updates not commited about the Swagger specification files
 3.  Add a Swagger job to check if the current specification files are valid

## 🧠 Premises/arguments for the requesting changes/updates
To get an error message about any updated related to the Swagger docs

Detailed bullet point list completed/to complete

* Workflow file created ✅ 
* Job to check if there are updates not commited ✅ 
* Job to validate the current Swagger specification files ✅ 

##  🏗  Implementation steps/approach
To check if there are any Swagger updates not commited, we are executing in a job the command to create the Swagger files, this will cause a difference, a non empty string output, if we run the `git diff` against the `docs`and there are any update.

For validating the Swager files, we are running the swagger tool with the subcommand validate and looking for the substring "is valid" in the returned output.

## 🚸 Potential issues or conflicts to monitor
This can cause an error when we hit the `/swagger/` endpoint if there is any uncommitted update or the specification files are not valid.

## 🧪 Test already done or in progress

* [x] Validate locally the action for checking uncommitted updates with [act](https://github.com/nektos/act)
* [x] Validate locally the action to verifying if the Swagger specification files are valid with [act](https://github.com/nektos/act) 
* [x] Verifying in this PR, the new created workflow is valid, _i.e_, the checks are in green
